### PR TITLE
Chapter 2, exercise 7: RTL support

### DIFF
--- a/python_browser/browser.py
+++ b/python_browser/browser.py
@@ -4,11 +4,13 @@ import tkinter
 from constants import HEIGHT, SCROLL_STEP, VSTEP, WIDTH
 from html_lexer import lex, transform
 from layout import layout
+from url import DataURL, FileURL, HttpURL
 from url import URL, AbstractURL
 
 
 class Browser:
-    def __init__(self):
+    def __init__(self, rtl: bool = False):
+        self.rtl = rtl
         self.scroll = 0
         self.screen_height = HEIGHT
         self.screen_width = WIDTH
@@ -32,7 +34,7 @@ class Browser:
         else:
             self.text = lex(body)
 
-        self.display_list, self.doc_height = layout(self.text)
+        self.display_list, self.doc_height = layout(self.text, rtl=self.rtl)
         self.draw()
 
     def draw(self):
@@ -84,13 +86,20 @@ class Browser:
     def resize(self, e):
         self.screen_height = e.height
         self.screen_width = e.width
-        self.display_list, self.doc_height = layout(self.text, self.screen_width)
+        self.display_list, self.doc_height = layout(
+            self.text, width=self.screen_width, rtl=self.rtl
+        )
         self.draw()
 
 
 if __name__ == "__main__":
-    import sys
+    import argparse
 
-    url = URL.create(sys.argv[1])
-    Browser().load(url)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("url")
+    parser.add_argument("--rtl", action="store_true")
+    args = parser.parse_args()
+
+    url: DataURL | FileURL | HttpURL = URL.create(args.url)
+    Browser(args.rtl).load(url)
     tkinter.mainloop()

--- a/python_browser/layout.py
+++ b/python_browser/layout.py
@@ -4,22 +4,30 @@ from constants import HSTEP, VSTEP, WIDTH
 DisplayListItem = tuple[float | int, float | int, str]
 
 
-def layout(text: str, width: int = WIDTH) -> tuple[list[DisplayListItem], float]:
+def layout(
+    text: str, width: int = WIDTH, rtl: bool = False
+) -> tuple[list[DisplayListItem], float]:
     display_list = []
-    cursor_x: float = HSTEP
+
+    x_start = width - HSTEP if rtl else HSTEP
+    x_end = HSTEP if rtl else width - HSTEP
+    x_inc = -HSTEP if rtl else HSTEP
+
+    cursor_x: float = x_start
     cursor_y: float = VSTEP
 
     for c in text:
         display_list.append((cursor_x, cursor_y, c))
-        cursor_x += HSTEP
+        cursor_x += x_inc
 
-        if cursor_x >= width - HSTEP:
+        x_out_of_bound = cursor_x < x_end if rtl else cursor_x > x_end
+        if x_out_of_bound:
             cursor_y += VSTEP
-            cursor_x = HSTEP
+            cursor_x = x_start
 
         # Ex. 2-1
         if c == "\n":
             cursor_y += VSTEP * 1.5
-            cursor_x = HSTEP
+            cursor_x = x_start
 
     return display_list, cursor_y

--- a/python_browser/tests/test_layout.py
+++ b/python_browser/tests/test_layout.py
@@ -1,0 +1,36 @@
+import unittest
+
+from python_browser.browser import Browser
+from python_browser.constants import HSTEP, WIDTH
+from python_browser.tests.utils import socket
+from python_browser.url import URL
+
+
+class TestLayout(unittest.TestCase):
+    def test_load(self):
+        socket.patch().start()
+        url = "http://browser.engineering/examples/example1-simple.html"
+        socket.respond(
+            url, b"HTTP/1.0 200 OK\r\n" + b"Header1: Value1\r\n\r\n" + b"abc"
+        )
+        browser = Browser()
+        browser.load(URL.create(url))
+        self.assertEqual(len(browser.display_list), 3)
+
+        x, _, text = browser.display_list[0]
+        self.assertEqual(x, HSTEP)
+        self.assertEqual(text, "a")
+
+    def test_rtl(self):
+        socket.patch().start()
+        url = "http://browser.engineering/examples/example1-simple.html"
+        socket.respond(
+            url, b"HTTP/1.0 200 OK\r\n" + b"Header1: Value1\r\n\r\n" + b"abc"
+        )
+        browser = Browser(rtl=True)
+        browser.load(URL.create(url))
+        self.assertEqual(len(browser.display_list), 3)
+
+        x, _, text = browser.display_list[0]
+        self.assertEqual(x, WIDTH - HSTEP)
+        self.assertEqual(text, "a")


### PR DESCRIPTION
- Updates browser script to take an optional command line flag indicating RTL direction
- Passes `rtl` variable through `Browser()` to `layout()`
- Set x-axis boundaries and write direction based on `rtl`
- Unit test