### PR TITLE
Chapter 3, exercise 2: Superscript tag support

### DIFF
--- a/python_browser/browser.py
+++ b/python_browser/browser.py
@@ -44,15 +44,21 @@ class Browser:
     def draw(self):
         self.canvas.delete("all")
 
-        for x, y, c, f in self.display_list:
+        for item in self.display_list:
             # Don't draw characters below viewing window
-            if y > self.scroll + self.screen_height:
+            if item.y > self.scroll + self.screen_height:
                 continue
             # Or above it
-            if y + VSTEP < self.scroll:
+            if item.y + VSTEP < self.scroll:
                 continue
 
-            self.canvas.create_text(x, y - self.scroll, text=c, font=f, anchor="nw")
+            self.canvas.create_text(
+                item.x,
+                item.y - self.scroll,
+                text=item.word,
+                font=item.font,
+                anchor="nw",
+            )
 
         if self.doc_height > self.screen_height:
             self.draw_scrollbar()

--- a/python_browser/layout.py
+++ b/python_browser/layout.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import tkinter.font
 from typing import Literal, Union
 
@@ -5,11 +6,19 @@ from constants import HSTEP, VSTEP, WIDTH
 from fonts import get_font
 from html_lexer import Tag, Text
 
-# X position (right), word, font
-LineItem = tuple[float, str, tkinter.font.Font]
+
+@dataclass
+class LineItem:
+    x: float
+    word: str
+    font: tkinter.font.Font
+    parent_tag: str | None
+
 
 # X position (right), Y position (bottom), word, font
-DisplayListItem = tuple[float, float, str, tkinter.font.Font]
+@dataclass
+class DisplayListItem(LineItem):
+    y: float
 
 
 class Layout:
@@ -23,6 +32,7 @@ class Layout:
         self.style: Literal["roman", "italic"] = "roman"
         self.weight: Literal["normal", "bold"] = "normal"
 
+        self.parent_tag = None
         self.line: list[LineItem] = []
         self.display_list: list[DisplayListItem] = []
 
@@ -39,55 +49,79 @@ class Layout:
             for word in token.text.split():
                 self.word(word)
         elif isinstance(token, Tag):
-            if token.tag == "i":
-                self.style = "italic"
-            elif token.tag == "/i":
-                self.style = "roman"
-            elif token.tag == "b":
-                self.weight = "bold"
-            elif token.tag == "/b":
-                self.weight = "normal"
-            elif token.tag == "small":
-                self.size -= 2
-            elif token.tag == "/small":
-                self.size += 2
-            elif token.tag == "big":
-                self.size += 4
-            elif token.tag == "/big":
-                self.size -= 4
-            elif token.tag == "br":
-                self.flush()
-            elif token.tag == "/p":
-                self.flush()
-                self.cursor_y += VSTEP
+            if not token.tag.startswith("/"):
+                self.parent_tag = token.tag
+                if token.tag == "i":
+                    self.style = "italic"
+                elif token.tag == "b":
+                    self.weight = "bold"
+                elif token.tag == "small":
+                    self.size -= 2
+                elif token.tag == "big":
+                    self.size += 4
+                elif token.tag == "sup":
+                    self.size /= 2
+                elif token.tag == "br":
+                    self.flush()
+            else:
+                self.parent_tag = None
+                if token.tag == "/i":
+                    self.style = "roman"
+                elif token.tag == "/b":
+                    self.weight = "normal"
+                elif token.tag == "/small":
+                    self.size += 2
+                elif token.tag == "/big":
+                    self.size -= 4
+                elif token.tag == "/sup":
+                    self.size *= 2
+                elif token.tag == "/p":
+                    self.flush()
+                    self.cursor_y += VSTEP
 
         self.height = self.cursor_y
         return self.display_list
 
     def word(self, word: str):
-        font = get_font(self.size, self.weight, self.style)
+        font = get_font(int(self.size), self.weight, self.style)
         w = font.measure(word)
 
         if self.cursor_x + w > WIDTH - HSTEP:
             self.flush()
 
-        self.line.append((self.cursor_x, word, font))
+        self.line.append(
+            LineItem(x=self.cursor_x, word=word, font=font, parent_tag=self.parent_tag)
+        )
         self.cursor_x += w + font.measure(" ")
 
     def flush(self):
         if not self.line:
             return
 
-        metrics = [font.metrics() for x, word, font in self.line]
+        metrics = [item.font.metrics() for item in self.line]
         max_ascent = max([metric["ascent"] for metric in metrics])
         baseline = self.cursor_y + 1.25 * max_ascent
 
-        for x, word, font in self.line:
-            y = baseline - font.metrics("ascent")
+        for item in self.line:
+            y = baseline - item.font.metrics("ascent")
+            x = item.x
+
+            if item.parent_tag == "sup":
+                y = baseline - max_ascent
+
             if self.rtl:
                 x_offset = self.width - self.cursor_x
                 x += x_offset
-            self.display_list.append((x, y, word, font))
+
+            self.display_list.append(
+                DisplayListItem(
+                    x=x,
+                    y=y,
+                    word=item.word,
+                    font=item.font,
+                    parent_tag=item.parent_tag,
+                )
+            )
 
         max_descent = max([metric["descent"] for metric in metrics])
         self.cursor_y = baseline + 1.25 * max_descent

--- a/python_browser/layout.py
+++ b/python_browser/layout.py
@@ -15,10 +15,12 @@ class LineItem:
     parent_tag: str | None
 
 
-# X position (right), Y position (bottom), word, font
 @dataclass
-class DisplayListItem(LineItem):
+class DisplayListItem:
+    x: float
     y: float
+    word: str
+    font: tkinter.font.Font
 
 
 class Layout:
@@ -119,7 +121,6 @@ class Layout:
                     y=y,
                     word=item.word,
                     font=item.font,
-                    parent_tag=item.parent_tag,
                 )
             )
 

--- a/python_browser/tests/test_layout.py
+++ b/python_browser/tests/test_layout.py
@@ -18,12 +18,12 @@ class TestLayout(unittest.TestCase):
         self.assertEqual(len(browser.display_list), 2)
 
         word1 = browser.display_list[0]
-        self.assertEqual(word1[0], HSTEP)
-        self.assertEqual(word1[2], "abc")
+        self.assertEqual(word1.x, HSTEP)
+        self.assertEqual(word1.word, "abc")
 
         word2 = browser.display_list[1]
-        self.assertGreater(word2[0], word1[0])
-        self.assertEqual(word2[2], "def")
+        self.assertGreater(word2.x, word1.x)
+        self.assertEqual(word2.word, "def")
 
     def test_rtl(self):
         socket.patch().start()
@@ -36,5 +36,26 @@ class TestLayout(unittest.TestCase):
         self.assertEqual(len(browser.display_list), 2)
 
         word1 = browser.display_list[0]
-        self.assertGreater(word1[0], HSTEP)
-        self.assertEqual(word1[2], "abc")
+        self.assertGreater(word1.x, HSTEP)
+        self.assertEqual(word1.word, "abc")
+
+    def test_superscript(self):
+        socket.patch().start()
+        url = "http://browser.engineering/examples/example1-simple.html"
+        socket.respond(
+            url,
+            b"HTTP/1.0 200 OK\r\n"
+            + b"Header1: Value1\r\n\r\n"
+            + b"<div>abc <sup>def</sup></div>",
+        )
+        browser = Browser()
+        browser.load(URL.create(url))
+        self.assertEqual(len(browser.display_list), 2)
+
+        word1 = browser.display_list[0]
+        word2 = browser.display_list[1]
+        self.assertEqual(word1.y, word2.y)
+
+        ascent1 = word1.font.metrics().get("ascent")
+        ascent2 = word2.font.metrics().get("ascent")
+        self.assertGreater(ascent1, ascent2)


### PR DESCRIPTION
This PR adds formatting for text inside `<sup>` tags, which is sized to half the current font size and raised to align with the max ascent of the line instead of baseline.

To accomplish the former, we halve `self.size` when entering a `<sup>` tag and undo this when exiting, similar to how other formatting tags are already being handled. To vertically align the superscript correctly, we tweak the `y` value for the item before appending it to the display list, which happens in `Layout.flush()`. Specifically, instead of aligning the NW corner of the word according to its font ascent value, we align based on the max ascent in the current line.

Unfortunately, there isn't a way to track a word's parent context in the current `Layout` data model, which means that we don't know if a word is part of a superscript when adding it to the display list. As an intermediate solution, we add a `parent_tag` field to capture this information during `Layout.token()`, but a better long-term approach would be to build layout as a tree (which happens in a future chapter). 