### PR TITLE
Chapter 3, exercise 1: Center H1 titles

### DIFF
--- a/python_browser/tests/test_layout.py
+++ b/python_browser/tests/test_layout.py
@@ -39,6 +39,27 @@ class TestLayout(unittest.TestCase):
         self.assertGreater(word1.x, HSTEP)
         self.assertEqual(word1.word, "abc")
 
+    def test_center_title(self):
+        socket.patch().start()
+        url = "http://browser.engineering/examples/example1-simple.html"
+        socket.respond(
+            url,
+            b"HTTP/1.0 200 OK\r\n"
+            + b"Header1: Value1\r\n\r\n"
+            + b'<h1 class="title">abc</h1><div>def</div>',
+        )
+        browser = Browser()
+        browser.load(URL.create(url))
+        self.assertEqual((len(browser.display_list)), 2)
+
+        word1 = browser.display_list[0]
+        word2 = browser.display_list[1]
+
+        # First word should be centered, so x coord is greater than default
+        self.assertGreater(word1.x, HSTEP)
+        # Second word should be on a new line
+        self.assertGreater(word2.y, word1.y)
+
     def test_superscript(self):
         socket.patch().start()
         url = "http://browser.engineering/examples/example1-simple.html"


### PR DESCRIPTION
Building on previous work to support RTL (or at least right-justified text) after the `layout()` -> `Layout()` refactor, this PR also adds the ability for text to be centered if it is within an `<h1 class="title">` element.

Briefly toyed with the idea of tracking alignment on individual words like in #2, but since we need to flush the line after the `<h1>` tag is closed, such a change is unnecessary. 