### PR TITLE
Chapter 3, exercise 5: <pre> tag

### DIFF
--- a/python_browser/fonts.py
+++ b/python_browser/fonts.py
@@ -16,3 +16,11 @@ def get_font(size: int, weight: FontWeight, style: FontStyle):
         label = tkinter.Label(font=font)
         FONTS[key] = (font, label)
     return FONTS[key][0]
+
+
+def get_mono_font():
+    mono_font = tkinter.font.Font(
+        family="Courier New", size=12, weight="normal", slant="roman"
+    )
+    tkinter.Label(font=mono_font)
+    return mono_font

--- a/python_browser/html_lexer.py
+++ b/python_browser/html_lexer.py
@@ -20,6 +20,9 @@ def lex(body: str):
     in_entity = False
     maybe_entity_str = ""
 
+    # Ex. 3-5
+    in_pre_tag = False
+
     for c in body:
         if c == "<":
             in_tag = True
@@ -27,9 +30,17 @@ def lex(body: str):
                 out.append(Text(buffer))
             buffer = ""
         elif c == ">":
-            in_tag = False
+            tag_name = buffer
+            if tag_name == "/pre":
+                in_pre_tag = False
+            elif tag_name == "pre":
+                in_pre_tag = True
+
             out.append(Tag(buffer))
             buffer = ""
+
+            if not in_pre_tag:
+                in_tag = False
         elif c == "&":
             in_entity = True
             maybe_entity_str += c

--- a/python_browser/test.html
+++ b/python_browser/test.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  </head>
+  <body>
+    <pre>
+Line       one
+
+
+
+Line two
+Really really loooooooooooooooooooooooooooooooooooooooooooooooong line
+    </pre>
+  </body>
+</html>

--- a/python_browser/test.html
+++ b/python_browser/test.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
   </head>
   <body>
+    <div>JavaScript Object Notation (<abbr>JSON</abbr>)</div>
     <pre>
 Line       one
 


### PR DESCRIPTION
Adds support for the `<pre>` tag, which prints its content as-is (e.g. preserving internal tags and whitespace) and applies a monospaced font styling.

There are three main parts to this solution:
1. In `lex`, tweak the logic so that we treat the entirety of characters between `<pre>` and `</pre>` as a single `Text` entity.
2. In `Layout.token()`, check if we're evaluating a `Text` entity while `self.parent_tag == True`. If this condition is true, then we split on the `\n` character, creating a list of "lines" instead of "words".
3. Call `Layout._handle_pre()` on each line (vs. calling `Layout.word()` on each word), which renders each line in monospace font. If the line is in fact a new line, just increment the X and Y cursors accordingly.

This solution requires some special casing across `lex` and the `Layout` class, but I think this is unavoidable due to the special treatment of whitespace characters.