### PR TITLE
Chapter 3, exercise 5: Update <pre> tag handling to support nested tags

### DIFF
--- a/python_browser/fonts.py
+++ b/python_browser/fonts.py
@@ -4,23 +4,22 @@ from typing import Literal
 
 FontStyle = Literal["roman", "italic"]
 FontWeight = Literal["normal", "bold"]
-FontCacheKey = tuple[int, FontWeight, FontStyle]
+FontCacheKey = tuple[str, int, FontWeight, FontStyle]
 
 FONTS: dict[FontCacheKey, tuple[tkinter.font.Font, tkinter.Label]] = {}
 
 
-def get_font(size: int, weight: FontWeight, style: FontStyle):
-    key = (size, weight, style)
+def get_default_font_family() -> str:
+    return tkinter.font.nametofont("TkDefaultFont").cget("family")
+
+
+def get_font(
+    size: int, weight: FontWeight, style: FontStyle, family: str = ""
+) -> tkinter.font.Font:
+    family = family or get_default_font_family()
+    key = (family, size, weight, style)
     if key not in FONTS:
-        font = tkinter.font.Font(size=size, weight=weight, slant=style)
+        font = tkinter.font.Font(family=family, size=size, weight=weight, slant=style)
         label = tkinter.Label(font=font)
         FONTS[key] = (font, label)
     return FONTS[key][0]
-
-
-def get_mono_font():
-    mono_font = tkinter.font.Font(
-        family="Courier New", size=12, weight="normal", slant="roman"
-    )
-    tkinter.Label(font=mono_font)
-    return mono_font

--- a/python_browser/html_lexer.py
+++ b/python_browser/html_lexer.py
@@ -20,9 +20,6 @@ def lex(body: str):
     in_entity = False
     maybe_entity_str = ""
 
-    # Ex. 3-5
-    in_pre_tag = False
-
     for c in body:
         if c == "<":
             in_tag = True
@@ -30,17 +27,11 @@ def lex(body: str):
                 out.append(Text(buffer))
             buffer = ""
         elif c == ">":
-            tag_name = buffer
-            if tag_name == "/pre":
-                in_pre_tag = False
-            elif tag_name == "pre":
-                in_pre_tag = True
-
-            out.append(Tag(buffer))
+            in_tag = False
+            if buffer:
+                print(buffer)
+                out.append(Tag(buffer))
             buffer = ""
-
-            if not in_pre_tag:
-                in_tag = False
         elif c == "&":
             in_entity = True
             maybe_entity_str += c

--- a/python_browser/test.html
+++ b/python_browser/test.html
@@ -12,7 +12,7 @@ Line       one
 
 
 
-Line two
+<b>Line two</b>
 Really really loooooooooooooooooooooooooooooooooooooooooooooooong line
     </pre>
   </body>

--- a/python_browser/tests/test_layout.py
+++ b/python_browser/tests/test_layout.py
@@ -1,7 +1,7 @@
 import unittest
 
 from python_browser.browser import Browser
-from python_browser.constants import HSTEP, WIDTH
+from python_browser.constants import HSTEP, VSTEP, WIDTH
 from python_browser.tests.utils import socket
 from python_browser.url import URL
 
@@ -78,3 +78,21 @@ class TestLayout(unittest.TestCase):
         for char in browser.display_list:
             if char.word.isalpha():
                 self.assertTrue(char.word.isupper())
+
+    def test_pre(self):
+        browser = self._init_browser("<pre>abc\n\n<b>d  ef</b></pre>")
+        self.assertEqual(len(browser.display_list), 3)
+
+        for word in browser.display_list:
+            self.assertEqual(word.font.cget("family"), "Courier New")
+
+        abc, d, ef = browser.display_list[:3]
+        self.assertEqual(abc.font.cget("weight"), "normal")
+        self.assertEqual(d.font.cget("weight"), "bold")
+        self.assertEqual(ef.font.cget("weight"), "bold")
+
+        # 2 newlines should be preserved between 'abc' and 'd'
+        self.assertGreaterEqual(d.y - abc.y, VSTEP * 2)
+
+        # 2 spaces should be preserved between 'd' and 'ef'
+        self.assertGreaterEqual(ef.x - d.x, d.font.measure(" ") * 2)


### PR DESCRIPTION
This PR is a follow-up to #5 in order to properly format nested tags within a `<pre>` block. It includes:
- Undoing changes to `lex` so that we don't handle everything within `<pre>` tags as a single `Text`
- Updating the font cache to handle monospaced font by adding font family to the cache key
- As before, splitting text on `\n` if within a `<pre>` tag, resulting in an array of lines, and manually incrementing `cursor_y` to reflect any newlines. In addition, now calling `Layout.word()` for individual words within a line and manually incrementing `cursor_x` to preserve whitespace.